### PR TITLE
Update dependencies to avoiding pinning to old Rust package versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "observability"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["freesig <tom.gowan@holo.host>"]
 edition = "2018"
 description = "Experimental tracing ideas"
@@ -27,7 +27,7 @@ tracing-subscriber = "0.2.15"
 
 opentelemetry = { version = "0.8", default-features = false, features = ["trace", "serialize"], optional = true }
 tracing-opentelemetry = { version = "0.8.0", optional = true }
-holochain_serialized_bytes = {version = "=0.0.45", optional = true }
+holochain_serialized_bytes = {version = "0.0", optional = true }
 serde = { version = "1", optional = true }
 serde_bytes = { version = "0.11", optional = true }
 tokio = { version = "0.2", features = [ "sync" ], optional = true }


### PR DESCRIPTION
o Specify the "0.0" version for holochain_serialized_bytes, to allow upstream packages to specify newer versions.

In order to execute the process of upgrading holochain to use more up-to-date "syn", etc., packages, we must avoid specifying specific, old versions.  By specifying just a major/minor version number, we can allow the upstream packages to move forward.