### PR TITLE
Pin version of `tracing-subscriber`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1.0.22"
 tracing = "0.1.21"
 tracing-core = "0.1.17"
 tracing-serde = "0.1.2"
-tracing-subscriber = "0.2.15"
+tracing-subscriber = "=0.2.15"
 
 opentelemetry = { version = "0.8", default-features = false, features = ["trace", "serialize"], optional = true }
 tracing-opentelemetry = { version = "0.8.0", optional = true }


### PR DESCRIPTION
While doing `cargo install --path crates/hc` in [latest develop](https://github.com/holochain/holochain/commit/6274388b1d6735a24b65e9888314931a300cf564), I get this error:

```
   Compiling holochain_util v0.0.3 (/home/guillem/projects/holochain/core/holochain/crates/holochain_util)
   Compiling stream-cancel v0.8.1
   Compiling tracing-opentelemetry v0.8.0
   Compiling quinn-proto v0.7.3
   Compiling holo_hash v0.0.5 (/home/guillem/projects/holochain/core/holochain/crates/holo_hash)
   Compiling num_enum v0.5.4
   Compiling intervallum v1.3.0
   Compiling async-std v1.10.0
   Compiling tokio-stream v0.1.7
   Compiling h2 v0.3.4
   Compiling tokio-tungstenite v0.13.0
   Compiling observability v0.1.3
error[E0412]: cannot find type `ParseError` in module `tracing_subscriber::filter`
   --> /home/guillem/projects/holochain/core/holochain/.cargo/registry/src/github.com-1ecc6299db9ec823/observability-0.1.3/src/lib.rs:353:58
    |
353 |         BadDirective(#[from] tracing_subscriber::filter::ParseError),
    |                                                          ^^^^^^^^^^ not found in `tracing_subscriber::filter`
    |
help: consider importing one of these items
    |
342 |     use chrono::ParseError;
    |
342 |     use crate::ParseError;
    |
```

Seems like new versions of tracing-subscriber broke compatibility with this crate. This PR locks in the specific version of the dependency. 

I can confirm this fixes the original command `cargo install --path crates/hc`